### PR TITLE
[FIX] Bug with CMake on Windows

### DIFF
--- a/config/cmake_ext_mod/HDFTests.c
+++ b/config/cmake_ext_mod/HDFTests.c
@@ -234,7 +234,7 @@ SIMPLE_TEST(struct stat sb; sb.st_blocks=0);
 
 int main(void)
 {
-  char *llwidthArgs[] = { "l64", "l", "L", "q", "ll", NULL };
+  char *llwidthArgs[] = { "I64", "l64", "l", "L", "q", "ll", NULL };
   char *s = malloc(128);
   char **currentArg = NULL;
   LL_TYPE x = (LL_TYPE)1048576 * (LL_TYPE)1048576;
@@ -396,7 +396,7 @@ int main(void)
 #endif
 
 #ifdef LONE_COLON
-int main(int argc, char * argv) 
+int main(int argc, char * argv)
 {
   return 0;
 }
@@ -445,7 +445,7 @@ int main ()
 {
 	PGNSI pGNSI;
 	pGNSI = (PGNSI) GetProcAddress(
-      GetModuleHandle(TEXT("kernel32.dll")), 
+      GetModuleHandle(TEXT("kernel32.dll")),
       "InitOnceExecuteOnce");
 	if(NULL == pGNSI)
 		return 1;

--- a/src/H5Omtime.c
+++ b/src/H5Omtime.c
@@ -21,6 +21,7 @@
 
 #define H5O_PACKAGE		/*suppress error about including H5Opkg	  */
 
+#include <time.h>
 #include "H5private.h"		/* Generic Functions			*/
 #include "H5Eprivate.h"		/* Error handling		  	*/
 #include "H5FLprivate.h"	/* Free lists                           */
@@ -223,6 +224,8 @@ H5O_mtime_decode(H5F_t UNUSED *f, hid_t UNUSED dxpl_id, H5O_t UNUSED *open_oh,
     the_time += tm.__tm_gmtoff;
 #elif defined(H5_HAVE_TIMEZONE)
     /* Linux libc-5 */
+    int timezone;
+    _get_timezone(&timezone);
     the_time -= timezone - (tm.tm_isdst?3600:0);
 #elif defined(H5_HAVE_BSDGETTIMEOFDAY) && defined(H5_HAVE_STRUCT_TIMEZONE)
     /* Irix5.3 */


### PR DESCRIPTION
@agramfort I have to do some modifications on those file to be sure OpenMEEG can have a check with appveyor.

The first fix is to correct a never-ending test as suggested by :
https://gitlab.kitware.com/ben.boeckel/vtk/commit/718941125d967015e366172dd09793268f4c9eb5

The second : on windows timezone is not defined in `time.h` as suggested by :+1: http://www.vtk.org/Bug/view.php?id=15534
